### PR TITLE
Enable shell-escape for docs and fix typo in comments on code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ doc/memoize-code.pdf: $(codedoc-source) \
 doc/memoize.pdf: $(manual-source) $(examples-src) $(PACKAGES.edtx)
 
 %.pdf: %.tex
-	latexmk -cd -lualatex -bibtex- $(LATEXMK) $<  && touch $@
+	latexmk -cd -lualatex -shell-escape -bibtex- $(LATEXMK) $<  && touch $@
 
 
 

--- a/memoize.edtx
+++ b/memoize.edtx
@@ -1502,7 +1502,7 @@
 %     computing |\mmz@code@mdfivesum| in |\Memoize|.  It was realized that it
 %     is needed for full Beamer support,
 %     see \href{https://github.com/sasozivanovic/memoize/issues/27}{GitHub
-%     issue #27}.
+%     issue \#27}.
 \newtoks\mmzSalt
 \mmzset{
   salt/.code=\expandafter\toksapp\expandafter\mmzSalt{#1,},


### PR DESCRIPTION
The two changes needed for the docs to build.