### PR TITLE
avoid applying fix for issue 25 on LuaTeX (#34)

### DIFF
--- a/memoize.edtx
+++ b/memoize.edtx
@@ -2260,9 +2260,13 @@
 \ifdef\XeTeXversion{%
   \def\mmz@shipout@unrotate{}%
 }{%
-  \def\mmz@shipout@unrotate{%
-    %<latex>\IfPDFManagementActiveTF{}{\pdfpageattr{/Rotate 0}}%
-    %<plain,context>\pdfpageattr{/Rotate 0}%
+  \ifdef\luatexversion{% may mean landscape bug remains, but avoids breaking memoize completely
+    \def\mmz@shipout@unrotate{}%
+  }{%
+    \def\mmz@shipout@unrotate{%
+      %<latex>\IfPDFManagementActiveTF{}{\pdfpageattr{/Rotate 0}}%
+      %<plain,context>\pdfpageattr{/Rotate 0}%
+    }%
   }%
 }
 % \end{macro}


### PR DESCRIPTION
All this does is not apply the rotation fix if the engine is LuaTeX. I don't know if a fix is required for LuaTeX but this at least should let memoize work in cases where rotation isn't an issue, so it might be useful if you don't have time to investigate further at the moment. Or it may be completely useless. The latter is, of course, overwhelmingly more probable than the former.