### PR TITLE
add minimal support for tagging

### DIFF
--- a/memoize.edtx
+++ b/memoize.edtx
@@ -2455,7 +2455,10 @@
   % Use the extern box, with the precise size as remembered at memoization.
   \wd\mmz@box=#3\relax
   \ht\mmz@box=#4\relax
+  % For LaTeX, we use the tagging sockets, which have noop plugs by default.
+%<latex>    \UseTaggingSocket{memoize/include/extern/before}{#3}{#4}{#5}%
   \mmz@typeset@box\mmz@box
+%<latex>    \UseTaggingSocket{memoize/include/extern/after}%
   % Record that we have used this extern.
   \pgfkeysalso{/mmz/record/used extern={\mmz@extern@path}}%
 }
@@ -4149,6 +4152,23 @@
   auto=\citefield{cite, args=l*mlm},
 }
 %</biblatex>
+% 
+% \subsection{Tagging}
+% \label{sec:code:tagsupport}
+%
+%<*latex>
+\input{memoize-tagsupport-code.tex}%
+%</latex>
+% 
+%<*tagsupport>
+% New sockets: \texttt{noop} plugs are created by default.
+% So users must do something else to actually get support for tagging,
+% but this is much easier to do with the sockets in the right places.
+% Otherwise it is difficult (impossible?) to wrap the tagging markup
+% correctly around the included extern.
+\NewTaggingSocket {memoize/include/extern/before} {3}
+\NewTaggingSocket {memoize/include/extern/after} {0}
+%</tagsupport>
 %<*mmz>
 %
 %

--- a/memoize.ins
+++ b/memoize.ins
@@ -38,5 +38,6 @@
   \file{memoize-extract-one.tex}{\from{memoize.dtx}{extract-one}}%
   \file{memoize-biblatex.code.tex}{\from{memoize.dtx}{biblatex}}%
   \file{memoize-beamer.code.tex}{\from{memoize.dtx}{beamer}}%
+  \file{memoize-tagsupport.code.tex}{\from{memoize.dtx}{tagsupport}}%
 }
 \endbatchfile


### PR DESCRIPTION
This adds extremely minimal support for tagging. By default, memoization will continue to destroy all tagging, but it provides a stable interface for the addition of tagging code. 

This matters because e.g. `memoize-ext`'s support for tagging is going to break if(when?) the `devel` branch gets released, since it redefines `\mmzIncludeExtern` in an incompatible way. 

This is currently untested. 